### PR TITLE
Fix entry-points

### DIFF
--- a/src/deppack.coffee
+++ b/src/deppack.coffee
@@ -159,7 +159,7 @@ loadFile = (filePath, opts, callback) ->
 
       deps = Object.keys(allFiles).map (key) -> allFiles[key]
       header = opts.header or getHeader(opts.name or getModuleRootName entryModuleFilePath)
-      packed = packDeps filePath, header, deps, opts.ignoreRequireDefinition
+      packed = packDeps entryModuleFilePath, header, deps, opts.ignoreRequireDefinition
       callback null, packed
 
     try


### PR DESCRIPTION
Imagine a module 'foo' containing files 'index.js' which requires
'./sub.js'. If we want to pack the module and all deps, we want it so
that require('foo') includes 'index.js', not 'sub.js'. However, deppack
currently takes this path:

  loadDeps('foo/index.js')
  readFileAndProcess('foo/index.js')
  loadDeps('foo/sub.js')
  readFileAndProcess('foo/sub.js')
  done('foo/sub.js')

The done() call doesn't actually take any arguments, but the done that
is called is in the scope of the second loadDeps. It seems that when we
arrive at the last module we read in that doesn't have any dependencies,
we use _that_ as the entry point name, which seems wrong.

Just use the entry point name, as above, for correct behavior.
